### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
-#HOW TO BUILD box2d-jquery
+# HOW TO BUILD box2d-jquery
 
-##BUILD
+## BUILD
 
 box2d-jquery is written mostly in coffee-script, with some dependencies in javascript.
 
@@ -55,7 +55,7 @@ section of [package.json](package.json)
 
 ------------------------------
 
-##VIEW
+## VIEW
 
 to view your local version of box2d-jquery do something like this
 
@@ -69,7 +69,7 @@ then visit
 
 ------------------------------
 
-##CODE
+## CODE
 
 the important files are
 

--- a/CHALLENGE.md
+++ b/CHALLENGE.md
@@ -1,4 +1,4 @@
-#box2d-jquery challenge for jquery europe 2013
+# box2d-jquery challenge for jquery europe 2013
 
 (something to do after the afterparty and during the breaks)
 
@@ -11,7 +11,7 @@ hi, welcome to the box2d-jquery challenge. the idea is simple: contribute to box
 
 
 
-###how does the challenge work
+### how does the challenge work
 
   * fork box2d-jquery
   * read [BUILD.md](BUILD.md) to understand how box2d-jquery is structured
@@ -34,7 +34,7 @@ then
 
 **all pull-requests must be compatible with the zlib license of box2d-jquery and box2dWeb**. no strings attached.
 
-##the challenges
+## the challenges
 
  0. make a twitter wall for #jqeu13 using box2d-jquery update: or [make it even cooler](http://www.fullstackoptimization.com/box2d-jquery/twitter-wall.html) 
  1. better touch handling (currently scroll and links are not useable on touch devices) - for this we will have to completely rewirte the touch/mouse event stuff (it must be applied to each DOM element, not globally, i think)
@@ -67,11 +67,11 @@ if i can't get rid of all RaspberryPis during the conference weekend (which is q
 
 
 
-##Q:"i think XYZ would be great (even though it's not in the challenges), look, here is the pull-request""
+## Q:"i think XYZ would be great (even though it's not in the challenges), look, here is the pull-request""
 
 A: cool! thx! contribute, talk to me, if it's the awesomeness of awesomeness and i still have one of the RaspberryPis you will probably get one.
 
-##Q:"i wanted to contribute, but hey man your code makes my eyes bleed"
+## Q:"i wanted to contribute, but hey man your code makes my eyes bleed"
 
 A: live with it, i'm a recreational coder. but i invite you to improve the code, the lib, everything. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#box2d-jQuery
+# box2d-jQuery
 
 
 `v0.8`
@@ -18,7 +18,7 @@ and start to **KICK STUFF AROUND** (with your mouse/touchpad pointer - or using 
 
 oh, and before i forget, stop by the jquery conference, it will be cool (i promise), and use the [voucher code 'fullstackoptimization'](http://jquery-eu-2013.eventbrite.com/?discount=fullstackoptimization) for 5% off.
 
-##acknowledgements
+## acknowledgements
 
 thx to box2dweb [http://code.google.com/p/box2dweb/](http://code.google.com/p/box2dweb/) which is the engine that works in the background.
 
@@ -27,13 +27,13 @@ thx to
 
 if you have questions, bug-reports and/or feature requests, please use the github-issue tracker and/or ping me at twitter ([@enzenhofer](https://twitter.com/enzenhofer))
 
-##how to contribute to box2d-jquery
+## how to contribute to box2d-jquery
 
 please see [BUILD.md](BUILD.md)
 
 also there is currently a [RaspberryPi4PullRequests Challenge](CHALLENGE.md)
 
-##how to use jquery.box2d.js
+## how to use jquery.box2d.js
 
 that's simple
 
@@ -169,7 +169,7 @@ HTML attributes > jquery options assignment, nuff said!
 
 ok, that's bascally it. any question? bugs (there are some, especially on non-newest-stuff browsers (i.e.: ipad 1))? other stuff? please use the issue tracker, i'm collectiong bugs right now.
 
-##in a nutshell, how does it work?
+## in a nutshell, how does it work?
 ok, you want the itty-gritty technical details well, look at the [source](https://github.com/franzenzenhofer/box2d-jquery/blob/master/js/src/main.coffee), that's the only real way. but in short
  * we clone the selected DOM elements into absolute possitioned ... well ... clones.
  * we animate them via dynamically (javascript styly) set CSS3 transforms / translate / rotate combos
@@ -188,7 +188,7 @@ ok, you want the itty-gritty technical details well, look at the [source](https:
  * change world boundaries with window resize
  * changes in the box2d HTML attributes should change the objects
 
-##license
+## license
   Copyright (C) 2012 - 305678 Franz Enzenhofer
   (see in source code licenses for other copyright holders)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
